### PR TITLE
doc: nrf52840dongle_nrf52840: fix build instructions for external probes

### DIFF
--- a/boards/arm/nrf52840dongle_nrf52840/doc/index.rst
+++ b/boards/arm/nrf52840dongle_nrf52840/doc/index.rst
@@ -295,6 +295,10 @@ Locate the DTS file for the board under: boards/arm/nrf52840dongle_nrf52840.
 This file requires a small modification to use a different partition table.
 Edit the include directive to include "fstab-debugger" instead of "fstab-stock".
 
+In addition, the Kconfig file in the same directory must be modified by setting
+``BOARD_HAS_NRF5_BOOTLOADER`` to be default ``n``, otherwise the code will be
+flashed with an offset.
+
 Then build and flash applications as usual (see :ref:`build_an_application` and
 :ref:`application_run` for more details).
 


### PR DESCRIPTION
In order for the application to be flashed beginning at address 0,
which is desired when flashing with an external probe,
BOARD_HAS_NRF5_BOOTLOADER must be set to n.

Signed-off-by: Jacob Siverskog <jacob@teenage.engineering>