### PR TITLE
Bluetooth: Mesh: Add queue_size and recv_win to lpn_cb

### DIFF
--- a/include/bluetooth/mesh/main.h
+++ b/include/bluetooth/mesh/main.h
@@ -425,14 +425,107 @@ int bt_mesh_lpn_set(bool enable);
  */
 int bt_mesh_lpn_poll(void);
 
-/** @brief Register a callback for Friendship changes.
+/** Low Power Node callback functions. */
+struct bt_mesh_lpn_cb {
+	/** @brief Friendship established.
+	 *
+	 *  This callback notifies the application that friendship has
+	 *  been successfully established.
+	 *
+	 *  @param net_idx  NetKeyIndex used during friendship establishment.
+	 *  @param friend_addr Friend address.
+	 *  @param queue_size  Friend queue size.
+	 *  @param recv_window Low Power Node's listens duration for
+	 *  Friend response.
+	 */
+	void (*established)(uint16_t net_idx, uint16_t friend_addr,
+			    uint8_t queue_size, uint8_t recv_window);
+
+	/** @brief Friendship terminated.
+	 *
+	 *  This callback notifies the application that friendship has
+	 *  been terminated.
+	 *
+	 *  @param net_idx  NetKeyIndex used during friendship establishment.
+	 *  @param friend_addr Friend address.
+	 */
+	void (*terminated)(uint16_t net_idx, uint16_t friend_addr);
+
+	/** @brief Local Poll Request.
+	 *
+	 *  This callback notifies the application that the local node has
+	 *  polled the friend node.
+	 *
+	 *  This callback will be called before @ref bt_mesh_lpn_cb::established
+	 *  when attempting to establish a friendship.
+	 *
+	 *  @param net_idx  NetKeyIndex used during friendship establishment.
+	 *  @param friend_addr Friend address.
+	 *  @param retry Retry or first poll request for each transaction.
+	 */
+	void (*polled)(uint16_t net_idx, uint16_t friend_addr, bool retry);
+};
+
+/** @def BT_MESH_LPN_CB_DEFINE
  *
- *  Registers a callback that will be called whenever Friendship gets
- *  established or is lost.
+ *  @brief Register a callback structure for Friendship events.
  *
- *  @param cb Function to call when the Friendship status changes.
+ *  @param _name Name of callback structure.
  */
-void bt_mesh_lpn_set_cb(void (*cb)(uint16_t friend_addr, bool established));
+#define BT_MESH_LPN_CB_DEFINE(_name)                                    \
+	static const Z_STRUCT_SECTION_ITERABLE(bt_mesh_lpn_cb,         \
+					       _CONCAT(bt_mesh_lpn_cb, \
+						       _name))
+
+/** Friend Node callback functions. */
+struct bt_mesh_friend_cb {
+	/** @brief Friendship established.
+	 *
+	 *  This callback notifies the application that friendship has
+	 *  been successfully established.
+	 *
+	 *  @param net_idx  NetKeyIndex used during friendship establishment.
+	 *  @param lpn_addr Low Power Node address.
+	 *  @param recv_delay Receive Delay in units of 1 millisecond.
+	 *  @param polltimeout PollTimeout in units of 1 millisecond.
+	 */
+	void (*established)(uint16_t net_idx, uint16_t lpn_addr,
+			    uint8_t recv_delay, uint32_t polltimeout);
+
+	/** @brief Friendship terminated.
+	 *
+	 *  This callback notifies the application that friendship has
+	 *  been terminated.
+	 *
+	 *  @param net_idx  NetKeyIndex used during friendship establishment.
+	 *  @param lpn_addr Low Power Node address.
+	 */
+	void (*terminated)(uint16_t net_idx, uint16_t lpn_addr);
+};
+
+/** @def BT_MESH_FRIEND_CB_DEFINE
+ *
+ *  @brief Register a callback structure for Friendship events.
+ *
+ *  Registers a callback structure that will be called whenever Friendship
+ *  gets established or terminated.
+ *
+ *  @param _name Name of callback structure.
+ */
+#define BT_MESH_FRIEND_CB_DEFINE(_name)                                   \
+	static const Z_STRUCT_SECTION_ITERABLE(bt_mesh_friend_cb,         \
+					       _CONCAT(bt_mesh_friend_cb, \
+						       _name))
+
+/** @brief Terminate Friendship.
+ *
+ *  Terminated Friendship for given LPN.
+ *
+ *  @param lpn_addr Low Power Node address.
+ *
+ *  @return Zero on success or (negative) error code otherwise.
+ */
+int bt_mesh_friend_terminate(uint16_t lpn_addr);
 
 #ifdef __cplusplus
 }

--- a/include/linker/common-rom.ld
+++ b/include/linker/common-rom.ld
@@ -107,6 +107,14 @@
 	Z_ITERABLE_SECTION_ROM(bt_mesh_app_key_cb, 4)
 #endif
 
+#if defined(CONFIG_BT_MESH_FRIEND)
+	Z_ITERABLE_SECTION_ROM(bt_mesh_friend_cb, 4)
+#endif
+
+#if defined(CONFIG_BT_MESH_LOW_POWER)
+	Z_ITERABLE_SECTION_ROM(bt_mesh_lpn_cb, 4)
+#endif
+
 #if defined(CONFIG_EC_HOST_CMD)
 	Z_ITERABLE_SECTION_ROM(ec_host_cmd_handler, 4)
 #endif

--- a/subsys/bluetooth/mesh/shell.c
+++ b/subsys/bluetooth/mesh/shell.c
@@ -500,16 +500,24 @@ static int cmd_poll(const struct shell *shell, size_t argc, char *argv[])
 	return 0;
 }
 
-static void lpn_cb(uint16_t friend_addr, bool established)
+static void lpn_established(uint16_t net_idx, uint16_t friend_addr,
+					uint8_t queue_size, uint8_t recv_win)
 {
-	if (established) {
-		shell_print(ctx_shell, "Friendship (as LPN) established to "
-			    "Friend 0x%04x", friend_addr);
-	} else {
-		shell_print(ctx_shell, "Friendship (as LPN) lost with Friend "
-			    "0x%04x", friend_addr);
-	}
+	shell_print(ctx_shell, "Friendship (as LPN) established to "
+			"Friend 0x%04x Queue Size %d Receive Window %d",
+			friend_addr, queue_size, recv_win);
 }
+
+static void lpn_terminated(uint16_t net_idx, uint16_t friend_addr)
+{
+	shell_print(ctx_shell, "Friendship (as LPN) lost with Friend "
+			"0x%04x", friend_addr);
+}
+
+BT_MESH_LPN_CB_DEFINE(lpn_cb) = {
+	.established = lpn_established,
+	.terminated = lpn_terminated,
+};
 
 #endif /* MESH_LOW_POWER */
 
@@ -544,10 +552,6 @@ static int cmd_init(const struct shell *shell, size_t argc, char *argv[])
 		shell_print(shell, "Use \"pb-adv on\" or \"pb-gatt on\" to "
 			    "enable advertising");
 	}
-
-#if IS_ENABLED(CONFIG_BT_MESH_LOW_POWER)
-	bt_mesh_lpn_set_cb(lpn_cb);
-#endif
 
 	return 0;
 }


### PR DESCRIPTION
Add Queue Size and Receive Window information to lpn
callback function to notify upper layer to determine
currently friend node information, which may be used
in future.

Add Callback structure to notification application which friendship
has been changed.

Add function `bt_mesh_friend_terminate` let's app layer determine
terminate friendship manually.

Signed-off-by: Lingao Meng <mengabc1086@gmail.com>